### PR TITLE
Ensure subpipeline to be isolated from the parent pipeline registry.

### DIFF
--- a/tfx/dsl/compiler/compiler_context.py
+++ b/tfx/dsl/compiler/compiler_context.py
@@ -95,6 +95,10 @@ class PipelineContext:
     self._implicit_downstream_nodes[parent_id].add(child_id)
 
   def _collect_conditional_dependency(self, here: base_node.BaseNode) -> None:
+    # TODO: b/321881540 - Should raise error if the node does not exist in the
+    # registry.
+    if here not in self.dsl_context_registry.all_nodes:
+      return
     for predicate in conditional.get_predicates(here,
                                                 self.dsl_context_registry):
       for chnl in channel_utils.get_dependent_channels(predicate):

--- a/tfx/dsl/component/experimental/decorators_test.py
+++ b/tfx/dsl/component/experimental/decorators_test.py
@@ -658,6 +658,7 @@ class ComponentDecoratorTest(tf.test.TestCase):
         components=[instance_1, instance_2])
     beam_dag_runner.BeamDagRunner().run(test_pipeline)
 
+    instance_1 = _injector_4()
     instance_2 = _json_compat_check_component(
         a=instance_1.outputs['d'],
         b=instance_1.outputs['e'],

--- a/tfx/dsl/component/experimental/decorators_typeddict_test.py
+++ b/tfx/dsl/component/experimental/decorators_typeddict_test.py
@@ -709,6 +709,7 @@ class ComponentDecoratorTest(tf.test.TestCase):
     )
     beam_dag_runner.BeamDagRunner().run(test_pipeline)
 
+    instance_1 = _injector_4()
     instance_2 = _json_compat_check_component(
         a=instance_1.outputs['d'],
         b=instance_1.outputs['e'],

--- a/tfx/dsl/context_managers/dsl_context.py
+++ b/tfx/dsl/context_managers/dsl_context.py
@@ -67,3 +67,6 @@ class DslContext:
 
   def __hash__(self):
     return hash(id(self))
+
+  def __str__(self) -> str:
+    return self.__class__.__qualname__

--- a/tfx/dsl/context_managers/dsl_context_manager_test.py
+++ b/tfx/dsl/context_managers/dsl_context_manager_test.py
@@ -42,12 +42,12 @@ class _FakeContext(dsl_context.DslContext):
   pass
 
 
-class _FakeContextManager(dsl_context_manager.DslContextManager):
+class _FakeContextManager(dsl_context_manager.DslContextManager[Any]):
 
-  def create_context(self) -> _FakeContext:
+  def create_context(self):
     return _FakeContext()
 
-  def enter(self, context: _FakeContext) -> _FakeContext:
+  def enter(self, context):
     return context
 
 
@@ -143,7 +143,7 @@ class ContextManagerTest(test_case_utils.TfxTest):
 
     class UltimateContextManager(_FakeContextManager):
 
-      def enter(self, context: _FakeContext) -> int:
+      def enter(self, context):
         return 42
 
     with UltimateContextManager() as captured:

--- a/tfx/dsl/context_managers/dsl_context_registry.py
+++ b/tfx/dsl/context_managers/dsl_context_registry.py
@@ -14,19 +14,16 @@
 """Module for DslContextRegistry."""
 
 import collections
+from collections.abc import Iterable, Iterator
 import contextlib
 import threading
-from typing import Any, List, Optional, Iterator
+from typing import Any, Optional
 
 from tfx.dsl.context_managers import dsl_context
 
 # Use Any to avoid cyclic import.
 _BaseNode = Any
 _Pipeline = Any
-
-
-def _format_node(node: _BaseNode) -> str:
-  return f'{type(node).__name__}({node.id})#{id(node)}'
 
 
 class DslContextRegistry:
@@ -41,10 +38,10 @@ class DslContextRegistry:
   def __init__(self):
     super().__init__()
     # Frame of currently active DSL context. Ordered by parent -> child.
-    self._active_contexts: List[dsl_context.DslContext] = []
+    self._active_contexts: list[dsl_context.DslContext] = []
     # All DSL contexts that have ever been defined so far.
-    self._all_contexts: List[dsl_context.DslContext] = []
-    self._all_nodes: List[_BaseNode] = []
+    self._all_contexts: list[dsl_context.DslContext] = []
+    self._all_nodes: list[_BaseNode] = []
     # Mapping from Context ID to a list of nodes that belong to each context.
     # Each list of node is sorted chronologically.
     self._nodes_by_context = collections.defaultdict(list)
@@ -62,12 +59,12 @@ class DslContextRegistry:
     return result
 
   @property
-  def all_contexts(self) -> List[dsl_context.DslContext]:
+  def all_contexts(self) -> list[dsl_context.DslContext]:
     """All contexts defined during the lifespan of the registry."""
     return list(self._all_contexts)
 
   @property
-  def active_contexts(self) -> List[dsl_context.DslContext]:
+  def active_contexts(self) -> list[dsl_context.DslContext]:
     """All active context frame in parent -> child order."""
     return list(self._active_contexts)
 
@@ -122,7 +119,10 @@ class DslContextRegistry:
     """Replaces one node instance to another in a registry."""
     self._check_mutable()
     if node_from not in self._all_nodes:
-      raise ValueError(f'{node_from} does not exist in pipeline registry.')
+      raise ValueError(
+          f'{node_from.id} does not exist in pipeline registry. Valid:'
+          f' {[n.id for n in self._all_nodes]}'
+      )
     self._all_nodes[self._all_nodes.index(node_from)] = node_to
     for context in self._all_contexts:
       nodes = self._nodes_by_context[context]
@@ -131,7 +131,7 @@ class DslContextRegistry:
         context.replace_node(node_from, node_to)
         context.validate(nodes)
 
-  def get_nodes(self, context: dsl_context.DslContext) -> List[_BaseNode]:
+  def get_nodes(self, context: dsl_context.DslContext) -> list[_BaseNode]:
     """Gets all BaseNodes that belongs to the context.
 
     Args:
@@ -145,7 +145,7 @@ class DslContextRegistry:
       raise ValueError(f'Context {context} does not exist in the registry.')
     return list(self._nodes_by_context[context])
 
-  def get_contexts(self, node: _BaseNode) -> List[dsl_context.DslContext]:
+  def get_contexts(self, node: _BaseNode) -> list[dsl_context.DslContext]:
     """Gets all dsl_context.DslContexts that the node belongs to.
 
     Args:
@@ -159,54 +159,80 @@ class DslContextRegistry:
     # This is O(N^2), but not performance critical.
     if node not in self._all_nodes:
       raise ValueError(
-          f'Node {_format_node(node)} does not exist in the registry. '
-          f'Valid: {", ".join([_format_node(n) for n in self._all_nodes])})')
+          f'Node {node.id} does not exist in the registry. Valid:'
+          f' {[n.id for n in self._all_nodes]})'
+      )
     result = []
     for context in self._all_contexts:
       if node in self._nodes_by_context[context]:
         result.append(context)
     return result
 
-  def extract_for_pipeline(self, pipeline: _Pipeline) -> 'DslContextRegistry':
+  def extract_for_pipeline(
+      self, nodes: Iterable[_BaseNode]
+  ) -> 'DslContextRegistry':
     """Creates new registry with pipeline level contexts filtered out.
 
     This function should be called in the pipeline constructor, i.e., where
     pipeine scope ends, to persist contexts defined within the pipeline scope
     in the pipeline object.
 
+    After the extraction, self no longer contains the extracted nodes and the
+    contexts from subpipeline registry.
+
     Args:
-      pipeline: A pipeline that may exist in the registry.
+      nodes: List of nodes that the pipeline contains. The pipeline itself does
+        not belong to the list.
+
     Returns:
-      A new DSL context registry with only contexts within the pipeline scope.
+      A new DSL context registry that contains the argument nodes.
     """
     # pylint:disable=protected-access
     result = DslContextRegistry()
-    latest_pipeline_level_context = None
-    for context in reversed(self._all_contexts):
-      if pipeline in self._nodes_by_context[context]:
-        latest_pipeline_level_context = context
-        break
-      else:
-        context.parent = None
-        result._all_contexts.append(context)
-    result._all_contexts.reverse()
+    if not nodes:
+      return result
 
-    result._active_contexts = []
+    self._check_mutable()
 
-    if latest_pipeline_level_context:
-      result._all_nodes = self._nodes_by_context[latest_pipeline_level_context]
-    else:
-      result._all_nodes = self._all_nodes
+    # Move nodes from self to result.
+    # We're preserving the original _all_nodes order (it matters).
+    # TODO: b/321881540 - Should raise error if the node does not exist in
+    # _all_nodes.
+    nodes_set = set(nodes)
+    result._all_nodes = [n for n in self._all_nodes if n in nodes_set]
+    self._all_nodes = [n for n in self._all_nodes if n not in nodes_set]
 
-    for context, nodes in self._nodes_by_context.items():
-      if context in result._all_contexts:
-        result._nodes_by_context[context] = [
-            n for n in nodes if n in result._all_nodes
-        ]
+    # Move contexts and associations from self to result.
+    for c in self._all_contexts:
+      # Outer contexts that should stay in self. Removing nodes context
+      # association is enough.
+      if c in self._active_contexts:
+        for n in result._all_nodes:
+          self._nodes_by_context[c].remove(n)
+        continue
 
-    result._finalized = False
+      # Other contexts may subject to extraction if it has association with
+      # nodes, otherwise irrelevant.
+      for n in nodes:
+        if n in self._nodes_by_context[c]:
+          result._nodes_by_context[c].append(n)
+
+      # Extracted contexts should be pruned from the self.
+      if result._nodes_by_context[c]:
+        result._all_contexts.append(c)
+        if not self._nodes_by_context[c]:
+          del self._nodes_by_context[c]
+          self._all_contexts.remove(c)
+
+    # Remove dangling context.parent.
+    for c in result._all_contexts:
+      if c.parent not in result._all_contexts:
+        c.parent = None
+
+    result._finalized = True
     # pylint:enable=protected-access
     return result
+
 
 _registry_holder = threading.local()
 

--- a/tfx/dsl/context_managers/dsl_context_registry_test.py
+++ b/tfx/dsl/context_managers/dsl_context_registry_test.py
@@ -1,0 +1,210 @@
+# Copyright 2024 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for tfx.dsl.context_managers.dsl_context_registry."""
+
+import tensorflow as tf
+from tfx.dsl.context_managers import dsl_context_registry
+from tfx.dsl.context_managers import test_utils
+
+Node = test_utils.Node
+TestContext = test_utils.TestContext
+
+
+class DslContextRegistryTest(tf.test.TestCase):
+
+  def assert_registry_equal(self, reg, expected):
+    test_utils.assert_registry_equal(self, reg, expected)
+
+  def testMultipleNodesAndContexts(self):
+    with dsl_context_registry.new_registry() as reg:
+      a = Node('A')
+      with TestContext('Ctx1') as foo1:
+        b = Node('B')
+        c = Node('C')
+        with TestContext('Ctx2') as foo2:
+          d = Node('D')
+        e = Node('E')
+      f = Node('F')
+
+    self.assert_registry_equal(
+        reg,
+        """
+        A
+        Ctx1 {
+          B
+          C
+          Ctx2 {
+            D
+          }
+          E
+        }
+        F
+        """,
+    )
+    self.assertEqual(reg.all_nodes, [a, b, c, d, e, f])
+    self.assertEqual(reg.all_contexts, [foo1, foo2])
+    self.assertEqual(reg.get_contexts(b), [foo1])
+    self.assertEqual(reg.get_contexts(d), [foo1, foo2])
+    self.assertEqual(reg.get_contexts(e), [foo1])
+    self.assertEqual(reg.get_contexts(f), [])
+
+  def testExtractForPipeline(self):
+    with dsl_context_registry.new_registry() as reg:
+      Node('A')
+      with TestContext('Ctx1'):
+        b = Node('B')
+        c = Node('C')
+        with TestContext('Ctx2'):
+          d = Node('D')
+        sub_reg = reg.extract_for_pipeline([b, c, d])
+        Node('E')
+      Node('F')
+
+    self.assert_registry_equal(
+        reg,
+        """
+        A
+        Ctx1 {
+          E
+        }
+        F
+        """,
+    )
+    self.assert_registry_equal(
+        sub_reg,
+        """
+        B
+        C
+        Ctx2 {
+          D
+        }
+        """,
+    )
+
+  def testExtractForPipeline_ActiveContextMatters(self):
+    with dsl_context_registry.new_registry() as reg:
+      with TestContext('Ctx1'):
+        a = Node('A')
+        reg1 = reg.extract_for_pipeline([a])
+        with TestContext('Ctx2'):
+          b = Node('B')
+          reg2 = reg.extract_for_pipeline([b])
+        with TestContext('Ctx3'):
+          c = Node('C')
+        reg3 = reg.extract_for_pipeline([c])
+        with TestContext('Ctx4'):
+          d = Node('D')
+      reg4 = reg.extract_for_pipeline([d])
+
+    self.assert_registry_equal(reg, '')
+    self.assert_registry_equal(reg1, 'A')
+    self.assert_registry_equal(reg2, 'B')
+    self.assert_registry_equal(
+        reg3,
+        """
+        Ctx3 {
+          C
+        }
+        """,
+    )
+    self.assert_registry_equal(
+        reg4,
+        """
+        Ctx1 {
+          Ctx4 {
+            D
+          }
+        }
+        """,
+    )
+
+  def testExtractForPipeline_OnlyExtractsRelevantContexts(self):
+    with dsl_context_registry.new_registry() as reg:
+      with TestContext('Ctx1'):
+        Node('A')
+        with TestContext('Ctx2'):
+          Node('B')
+        with TestContext('Ctx3'):
+          with TestContext('Ctx4'):
+            c = Node('C')
+          sub_reg = reg.extract_for_pipeline([c])
+          Node('D')
+
+    self.assert_registry_equal(
+        reg,
+        """
+        Ctx1 {
+          A
+          Ctx2 {
+            B
+          }
+          Ctx3 {
+            D
+          }
+        }
+        """,
+    )
+    self.assert_registry_equal(
+        sub_reg,
+        """
+        Ctx4 {
+          C
+        }
+        """,
+    )
+
+  def testReplaceNode(self):
+    with dsl_context_registry.new_registry() as reg:
+      a = Node('A')
+      with TestContext('Ctx1'):
+        b = Node('B')
+        c = Node('C')
+        with TestContext('Ctx2'):
+          d = Node('D')
+        e = Node('E')
+      f = Node('F')
+
+    reg.replace_node(a, Node('A_copy'))
+    reg.replace_node(b, Node('B_copy'))
+    reg.replace_node(c, Node('C_copy'))
+    reg.replace_node(d, Node('D_copy'))
+    reg.replace_node(e, Node('E_copy'))
+    reg.replace_node(f, Node('F_copy'))
+
+    self.assert_registry_equal(
+        reg,
+        """
+        A_copy
+        Ctx1 {
+          B_copy
+          C_copy
+          Ctx2 {
+            D_copy
+          }
+          E_copy
+        }
+        F_copy
+        """,
+    )
+
+  def testFinalize(self):
+    with dsl_context_registry.new_registry() as reg:
+      Node('A')
+      reg.finalize()
+      with self.assertRaises(RuntimeError):
+        Node('B')
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tfx/dsl/context_managers/test_utils.py
+++ b/tfx/dsl/context_managers/test_utils.py
@@ -1,0 +1,96 @@
+# Copyright 2024 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility for context manager testing."""
+
+import textwrap
+
+from absl.testing import absltest
+from tfx.dsl.components.base import base_node
+from tfx.dsl.context_managers import dsl_context
+from tfx.dsl.context_managers import dsl_context_manager
+from tfx.dsl.context_managers import dsl_context_registry
+
+
+class _TestContext(dsl_context.DslContext):
+
+  def __init__(self, name):
+    self._name = name
+
+  def __str__(self):
+    return self._name
+
+
+class TestContext(dsl_context_manager.DslContextManager[_TestContext]):
+
+  def __init__(self, name):
+    super().__init__()
+    self._name = name
+
+  def create_context(self):
+    return _TestContext(self._name)
+
+  def enter(self, context):
+    return context
+
+
+class Node(base_node.BaseNode):
+  inputs = {}
+  outputs = {}
+  exec_properties = {}
+
+  def __init__(self, name):
+    super().__init__()
+    self.with_id(name)
+
+
+def _debug_str(reg: dsl_context_registry.DslContextRegistry):
+  """Returns a debug string for the registry."""
+  frame = []
+  output_builder = []
+  indent = 0
+  for node in reg.all_nodes:
+    next_frame = reg.get_contexts(node)
+    for context in reversed(frame):
+      if context not in next_frame:
+        assert frame.pop() == context
+        indent -= 2
+        output_builder.append(' ' * indent + '}')
+    assert frame == next_frame[: len(frame)]
+    for context in next_frame:
+      if context not in frame:
+        if frame:
+          assert context.parent == frame[-1]
+        else:
+          assert context.parent is None
+        frame.append(context)
+        output_builder.append(' ' * indent + f'{context} {{')
+        indent += 2
+    output_builder.append(' ' * indent + node.id)
+  while frame:
+    frame.pop()
+    indent -= 2
+    output_builder.append(' ' * indent + '}')
+  return '\n'.join(output_builder)
+
+
+def assert_registry_equal(
+    test_case: absltest.TestCase,
+    reg: dsl_context_registry.DslContextRegistry,
+    expected_debug_str: str,
+):
+  expected = textwrap.dedent(expected_debug_str).strip()
+  actual = _debug_str(reg)
+  return test_case.assertEqual(
+      expected, actual, f'Expected:\n{expected}\n\nActual:\n{actual}\n'
+  )

--- a/tfx/dsl/control_flow/for_each_internal.py
+++ b/tfx/dsl/control_flow/for_each_internal.py
@@ -45,7 +45,9 @@ class ForEachContext(dsl_context.DslContext):
 
     if len(containing_nodes) > 1:
       raise NotImplementedError(
-          'Cannot define more than one component within ForEach yet.')
+          'Cannot define more than one component within ForEach yet. Got'
+          f' {[n.id for n in containing_nodes]}'
+      )
 
     # TODO(b/237363715): Raise if contaning nodes does not use loop variable
     # neither directly nor indirectly.

--- a/tfx/dsl/control_flow/for_each_test.py
+++ b/tfx/dsl/control_flow/for_each_test.py
@@ -125,16 +125,14 @@ class ForEachTest(test_case_utils.TfxTest):
     context2 = dsl_context_registry.get().get_contexts(c2)[-1]
     self.assertNotEqual(context1, context2)
 
-  # TODO(b/247709394): This should be removed once subpipelines are supported.
-  def testForEach_Subpipeline_NotImplemented(self):
+  def testForEach_Subpipeline(self):
     a = A()
-    with self.assertRaises(NotImplementedError):
-      with for_each.ForEach(a.outputs['aa']) as aa:
-        p_in = pipeline_lib.PipelineInputs({'aa': aa})
-        b = B(aa=p_in.inputs['aa'])
-        pipeline_lib.Pipeline(
-            pipeline_name='foo', components=b, inputs=p_in, outputs={}
-        )
+    with for_each.ForEach(a.outputs['aa']) as aa:
+      p_in = pipeline_lib.PipelineInputs({'aa': aa})
+      b = B(aa=p_in.inputs['aa'])
+      pipeline_lib.Pipeline(
+          pipeline_name='foo', components=[b], inputs=p_in, outputs={}
+      )
 
 
 if __name__ == '__main__':

--- a/tfx/orchestration/kubeflow/kubeflow_dag_runner.py
+++ b/tfx/orchestration/kubeflow/kubeflow_dag_runner.py
@@ -416,7 +416,7 @@ class KubeflowDagRunner(tfx_runner.TfxRunner):
     if self._exit_handler:
       original_pipeline = pipeline
       pipeline = copy.copy(original_pipeline)
-      pipeline.components.append(self._exit_handler)
+      pipeline.components = [*pipeline.components, self._exit_handler]
 
     for component in pipeline.components:
       # TODO(b/187122662): Pass through pip dependencies as a first-class

--- a/tfx/orchestration/kubeflow/v2/pipeline_builder.py
+++ b/tfx/orchestration/kubeflow/v2/pipeline_builder.py
@@ -223,6 +223,8 @@ class PipelineBuilder:
       exit_handler_image = _get_component_image(
           self._default_image, self._exit_handler.id
       )
+      with self._pipeline.dsl_context_registry.temporary_mutable():
+        self._pipeline.dsl_context_registry.put_node(self._exit_handler)
       # construct root with exit handler
       exit_handler_task = step_builder.StepBuilder(
           node=self._exit_handler,

--- a/tfx/orchestration/kubeflow/v2/step_builder_test.py
+++ b/tfx/orchestration/kubeflow/v2/step_builder_test.py
@@ -274,7 +274,9 @@ class StepBuilderTest(tf.test.TestCase):
             component_defs=component_defs,
             deployment_config=pipeline_pb2.PipelineDeploymentConfig(),
             dynamic_exec_properties=dynamic_exec_properties,
-            dsl_context_reg=dsl_context_registry.get()).build())
+            dsl_context_reg=pipeline.dsl_context_registry,
+        ).build()
+    )
     self.assertProtoEquals(
         test_utils.get_proto_from_test_data(
             'expected_dynamic_execution_properties_upstream_component_spec.pbtxt',
@@ -295,7 +297,9 @@ class StepBuilderTest(tf.test.TestCase):
             component_defs=component_defs,
             deployment_config=pipeline_pb2.PipelineDeploymentConfig(),
             dynamic_exec_properties=dynamic_exec_properties,
-            dsl_context_reg=dsl_context_registry.get()).build())
+            dsl_context_reg=pipeline.dsl_context_registry,
+        ).build()
+    )
     self.assertProtoEquals(
         test_utils.get_proto_from_test_data(
             'expected_dynamic_execution_properties_downstream_component_task.pbtxt',
@@ -317,7 +321,7 @@ class StepBuilderTest(tf.test.TestCase):
           component_defs=component_defs,
           deployment_config=pipeline_pb2.PipelineDeploymentConfig(),
           dynamic_exec_properties=dynamic_exec_properties,
-          dsl_context_reg=dsl_context_registry.get(),
+          dsl_context_reg=pipeline.dsl_context_registry,
       ).build()
 
   def testBuildLatestBlessedModelStrategySucceed(self):

--- a/tfx/orchestration/pipeline_test.py
+++ b/tfx/orchestration/pipeline_test.py
@@ -24,12 +24,18 @@ from tfx.dsl.components.base import base_component
 from tfx.dsl.components.base import base_executor
 from tfx.dsl.components.base import base_node
 from tfx.dsl.components.base import executor_spec
+from tfx.dsl.context_managers import dsl_context_registry
+from tfx.dsl.context_managers import test_utils
 from tfx.dsl.placeholder import placeholder as ph
 from tfx.orchestration import metadata
 from tfx.orchestration import pipeline
 from tfx.types.component_spec import ChannelParameter
 from tfx.types.component_spec import ExecutionParameter
 from tfx.utils import test_case_utils
+
+
+Node = test_utils.Node
+TestContext = test_utils.TestContext
 
 
 class _OutputArtifact(types.Artifact):
@@ -142,6 +148,7 @@ class _OutputTypeE(types.Artifact):
 
 
 class PipelineTest(test_case_utils.TfxTest):
+  assert_registry_equal = test_utils.assert_registry_equal
 
   def setUp(self):
     super().setUp()
@@ -398,6 +405,52 @@ class PipelineTest(test_case_utils.TfxTest):
     ]
     self.assertEqual(expected_args,
                      p.components[0].executor_spec.beam_pipeline_args)
+
+  def testNestedPipelineRegistry(self):
+    with dsl_context_registry.new_registry() as reg:
+      with TestContext('Ctx1'):
+        a = Node('A')
+        b = Node('B')
+        with TestContext('Ctx2'):
+          c = Node('C')
+          with TestContext('Ctx3'):
+            d = Node('D')
+          p1 = pipeline.Pipeline(pipeline_name='p1', components=[c, d])
+        p2 = pipeline.Pipeline(pipeline_name='p2', components=[b, p1])
+      p3 = pipeline.Pipeline(pipeline_name='p3', components=[a, p2])
+
+    p1.finalize()
+    p2.finalize()
+    p3.finalize()
+
+    self.assert_registry_equal(
+        p1.dsl_context_registry,
+        """
+        C
+        Ctx3 {
+          D
+        }
+        """,
+    )
+    self.assert_registry_equal(
+        p2.dsl_context_registry,
+        """
+        B
+        Ctx2 {
+          p1
+        }
+        """,
+    )
+    self.assert_registry_equal(
+        p3.dsl_context_registry,
+        """
+        Ctx1 {
+          A
+          p2
+        }
+        """,
+    )
+    self.assert_registry_equal(reg, 'p3')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Recreated from original PR: https://github.com/tensorflow/tfx/pull/6591

Ensure subpipeline to be isolated from the parent pipeline registry.

Previously we had `DslContextRegistry.extract_for_pipeline` for this exact purpose, but two problems:

1. The extracted nodes and contexts are not moved but copied from the parent registry, so that parent registry was seeing the nodes from the subpipelines which it shouldn't. This caused subpipeline to not correctly work with the Cond or ForEach.
2. `extract_for_pipeline` was only triggered when there exists any active DslCont...